### PR TITLE
Altera nome do Programa para Periferia Viva - Reformas na página erro 500

### DIFF
--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -1134,7 +1134,7 @@ view:
     title: Ocorreu um erro
     subtitle: Algo inesperado aconteceu.
     text_first: Não conseguimos processar sua solicitação agora.
-    text_second: Mas não se preocupe, você pode tentar novamente mais tarde ou navegar por outras páginas da Plataforma Periferia Viva - Reformas. #alterado
+    text_second: Mas não se preocupe, você pode tentar novamente mais tarde ou navegar por outras páginas da Plataforma Periferia Viva - Reformas.
     dashboard: Voltar para o painel de controle
     image: Erro
 


### PR DESCRIPTION
Altera nome do Programa para Periferia Viva - Reformas na página erro 500.

Print de validação da alteração
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/9e1fb21c-8053-4e70-96c5-97920be48d6a" />
