### PR TITLE
fix: corrigir findOrganizationByCityId para evitar múltiplos resultados

### DIFF
--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -82,6 +82,10 @@ class OrganizationRepository extends AbstractRepository implements OrganizationR
                 SELECT *
                 FROM organization o
                 WHERE o.extra_fields->>'cityId' = :cityId
+                AND o.type = 'Municipio'
+                AND o.deleted_at IS NULL
+                ORDER BY o.created_at DESC
+                LIMIT 1
             SQL;
 
         $query = $this->getEntityManager()->createNativeQuery($sql, $rsm);


### PR DESCRIPTION
## Fix: Corrigir erro ao buscar município durante submissão de proposta

**Problema**: Query `findOrganizationByCityId()` retornava múltiplos resultados, causando erro 500

**Solução**: 
- Filtrar apenas organizações do tipo 'Municipio'
- Excluir da busca registros deletados
- Retornar o mais recente em caso de duplicatas (LIMIT 1)

**Resultado**: Propostas podem ser enviadas com sucesso