### PR TITLE
Altera o título para entidades na pagina de detalhe da empresa

### DIFF
--- a/templates/regmel/admin/company/details.html.twig
+++ b/templates/regmel/admin/company/details.html.twig
@@ -13,7 +13,14 @@
         <div class="management-content w-100 p-4">
             <div class="card card-body shadow">
                 <div class="d-flex justify-content-between">
-                    <h2>{{ 'company'|trans }} - {{ company.name }}</h2>
+                    <h2>
+                        {% if company.extraFields.tipo == 'Entidade' %}
+                            OSC
+                        {% else %}
+                            {{ 'company'|trans }}
+                        {% endif %}
+                        - {{ company.name }}
+                    </h2>
 
                     <div class="col text-end">
                         <a href="#"


### PR DESCRIPTION
Altera o título para 'OSC' quando a empresa for uma Entidade. 
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/5e31a54a-832c-4f18-a0cf-7cc486f200e7" />
