### PR TITLE
fix: sincronizar validação de força de senha entre frontend e backend

### DIFF
--- a/src/DTO/UserDto.php
+++ b/src/DTO/UserDto.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\DTO;
 
 use App\Validator\Constraints\NotNull;
+use App\Validator\Constraints\RegmelPasswordStrength;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\PasswordStrength;
 use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Uuid;
@@ -58,8 +58,7 @@ class UserDto
     #[Sequentially([
         new NotBlank(groups: [self::CREATE]),
         new NotNull(groups: [self::UPDATE]),
-        new PasswordStrength(
-            minScore: PasswordStrength::STRENGTH_WEAK,
+        new RegmelPasswordStrength(
             message: 'password.too_weak',
             groups: [self::CREATE, self::UPDATE]
         ),

--- a/src/Validator/Constraints/RegmelPasswordStrength.php
+++ b/src/Validator/Constraints/RegmelPasswordStrength.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class RegmelPasswordStrength extends Constraint
+{
+    public string $message = 'password.too_weak';
+
+    public function __construct(?string $message = null, ?array $groups = null, mixed $payload = null)
+    {
+        parent::__construct([], $groups, $payload);
+
+        if ($message !== null) {
+            $this->message = $message;
+        }
+    }
+}

--- a/src/Validator/Constraints/RegmelPasswordStrengthValidator.php
+++ b/src/Validator/Constraints/RegmelPasswordStrengthValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class RegmelPasswordStrengthValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof RegmelPasswordStrength) {
+            throw new UnexpectedTypeException($constraint, RegmelPasswordStrength::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        // Padrão do frontend: 8+ caracteres, minúscula, maiúscula, dígito, caractere especial
+        $passwordPattern = '/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/';
+
+        if (!preg_match($passwordPattern, $value)) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
- Criar validador customizado RegmelPasswordStrength para usar o mesmo padrão de regex do frontend
- Atualizar UserDto para usar o novo validador customizado

📝 Resumo da Alteração: Sincronização da Validação de Senha
🔴 Problema
O frontend mostrava que a senha era forte, mas o backend rejeitava a mesma senha dizendo que era fraca. Isso ocorria porque usavam validadores diferentes.

✅ Solução
Criamos um validador customizado no backend (RegmelPasswordStrength) que usa exatamente o mesmo padrão de validação do frontend.

📋 Arquivos Alterados
UserDto.php

Substituiu o validador PasswordStrength (do Symfony) pelo novo RegmelPasswordStrength
RegmelPasswordStrength.php (novo)

Define o constraint customizado
RegmelPasswordStrengthValidator.php (novo)

Implementa a lógica de validação usando o mesmo regex do frontend
🔐 Requisitos de Senha (Agora Sincronizados)
✅ Mínimo 8 caracteres
✅ Pelo menos uma letra minúscula
✅ Pelo menos uma letra MAIÚSCULA
✅ Pelo menos um número
✅ Pelo menos um caractere especial (!@#$%&*)

📌 Impacto
Usuários não receberão mais erros confusos de "senha fraca"
A validação agora é consistente entre frontend e backend
Senhas fortes são aceitas em ambos os lados
