### PR TITLE
feat: adiciona funcionalidade de exclusão de propostas no painel admin

### DIFF
--- a/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
+++ b/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
@@ -378,4 +378,27 @@ class ProposalAdminController extends AbstractAdminController
 
         return $this->redirectToRoute('admin_regmel_proposal_list');
     }
+
+    #[IsGranted(UserRolesEnum::ROLE_ADMIN->value, statusCode: self::ACCESS_DENIED_RESPONSE_CODE)]
+    #[Route('/painel/admin/propostas/{id}/remover', name: 'admin_regmel_proposal_remove', methods: ['GET'])]
+    public function remove(Uuid $id): Response
+    {
+        try {
+            $proposal = $this->initiativeService->get($id);
+            $proposalStatus = $proposal->getExtraFields()['status'] ?? '';
+
+            // Verificar se a proposta tem status "Anuída" ou "Selecionada"
+            if ($proposalStatus === StatusProposalEnum::ANUIDA->value || $proposalStatus === StatusProposalEnum::SELECIONADA->value) {
+                $this->addFlash('error', $this->translator->trans('view.proposal.error.cannot_delete_approved'));
+                return $this->redirectToRoute('admin_regmel_proposal_list');
+            }
+
+            $this->initiativeService->remove($id);
+            $this->addFlashSuccess($this->translator->trans('view.proposal.message.deleted'));
+        } catch (Exception $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_regmel_proposal_list');
+    }
 }

--- a/src/Repository/InitiativeRepository.php
+++ b/src/Repository/InitiativeRepository.php
@@ -56,6 +56,8 @@ class InitiativeRepository extends AbstractRepository implements InitiativeRepos
                 ->setParameter('anticipation', $anticipation);
         }
 
+        $queryBuilder->andWhere('i.deleted_at IS NULL');
+
         $ids = $queryBuilder->executeQuery()->fetchFirstColumn();
         if (empty($ids)) {
             return [];

--- a/templates/regmel/admin/proposal/list.html.twig
+++ b/templates/regmel/admin/proposal/list.html.twig
@@ -7,6 +7,7 @@
 {% block content %}
 <section class="d-flex">
     {% include "_components/side-bar.html.twig" %}
+    {% include "_components/modal-confirm-remove.html.twig" %}
 
     <div class="my-3 container-fluid">
         <div class="row">
@@ -158,6 +159,22 @@
                                                 </a>
                                             </li>
                                             {% endif %}
+                                            {% if is_granted('ROLE_ADMIN') %}
+                                            <li><hr class="dropdown-divider"></li>
+                                            <li>
+                                                <a
+                                                        href="#"
+                                                        class="dropdown-item text-danger"
+                                                        data-cy="remove-{{ proposal.id }}"
+                                                        data-bs-toggle="modal"
+                                                        data-bs-target="#modalRemoveConfirm"
+                                                        onclick="confirmRemove(this)"
+                                                        data-href="{{ path('admin_regmel_proposal_remove', {id: proposal.id}) }}"
+                                                >
+                                                    Excluir Proposta
+                                                </a>
+                                            </li>
+                                            {% endif %}
                                         </ul>
                                     </div>
                                 </td>
@@ -184,6 +201,7 @@
     <script src="https://unpkg.com/gridjs/plugins/selection/dist/selection.umd.js"></script>
     <script type="module" src="{{ asset('js/regmel/grid-init-proposals.js') }}"></script>
     <script src="{{ asset('js/modal-proposal-details.js') }}"></script>
+    <script src="{{ asset('js/modal-confirm-remove.js') }}"></script>
     <script type="module" src="{{ asset('js/load-filters.js') }}"></script>
 
     <script>

--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -857,6 +857,12 @@ view:
     message:
       created: A Iniciativa foi criada com sucesso
       deleted: A Iniciativa foi excluída
+
+  proposal:
+    message:
+      deleted: A proposta foi excluída
+    error:
+      cannot_delete_approved: Não é possível excluir uma proposta que foi anuída ou selecionada
     project_linked_program: Este projeto está vinculado ao programa programa-nome e foi selecionado por meio da oportunidade oportunidade-nome.
     quantity:
       total: Iniciativas Encontradas


### PR DESCRIPTION
- Implementa rota GET em /painel/admin/propostas/{id}/remover com segurança restrita a ROLE_ADMIN
- Adiciona botão 'Excluir Proposta' no dropdown de ações da listagem de propostas
- Integra modal de confirmação de exclusão com padrão modal-confirm-remove
- Implementa validação de segurança: propostas com status 'Anuída' ou 'Selecionada' não podem ser deletadas
- Adiciona filtro deletedAt IS NULL no InitiativeRepository.findByFilters() para não exibir propostas deletadas
- Adiciona mensagens de tradução:
  - view.proposal.message.deleted: 'A proposta foi excluída'
  - view.proposal.error.cannot_delete_approved: 'Não é possível excluir uma proposta que foi anuída ou selecionada'

Requisitos atendidos:
✓ Botão de exclusão apenas visível e funcional para administradores ✓ Modal de confirmação antes de deletar
✓ Propostas anuídas/selecionadas protegidas contra exclusão ✓ Propostas deletadas não aparecem mais na listagem ✓ Mensagens de sucesso e erro apropriadas

<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/8964f69d-38dd-425c-9c0e-b9c25a593322" />

<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/56540b08-cac7-4b9b-b24a-030f1be8c870" />

<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/c81e9533-5271-414a-9280-476705b88ba1" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4d6b6857-6f3f-4de5-92a1-425c9e710946" />
