### PR TITLE
fix: atualizar contagem de propostas em tempo real no dashboard

### DIFF
--- a/src/Controller/Web/Admin/DashboardAdminController.php
+++ b/src/Controller/Web/Admin/DashboardAdminController.php
@@ -83,14 +83,8 @@ class DashboardAdminController extends AbstractAdminController
             'type' => OrganizationTypeEnum::EMPRESA->value,
         ]));
         
-        // Propostas são iniciativas com campos específicos (map_file, project_file, etc)
-        $allInitiatives = $isAdminOrManagerOrSupport 
-            ? $this->initiativeService->findBy([], PHP_INT_MAX)
-            : $this->initiativeService->findBy(['createdBy' => $createdBy], PHP_INT_MAX);
-        $totalProposals = count(array_filter($allInitiatives, function($initiative) {
-            $extraFields = $initiative->getExtraFields();
-            return isset($extraFields['map_file']) || isset($extraFields['project_file']);
-        }));
+        // Propostas: usa query direta ao banco sem cache para contar em tempo real
+        $totalProposals = $this->initiativeService->countProposals($createdBy);
 
         $totals = [
             'totalUsers' => $totalUsers,

--- a/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
+++ b/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
@@ -17,6 +17,7 @@ use App\Service\Interface\InscriptionOpportunityServiceInterface;
 use App\Service\Interface\OrganizationServiceInterface;
 use App\Service\Interface\PhaseServiceInterface;
 use App\Service\Interface\StateServiceInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -42,6 +43,7 @@ class ProposalAdminController extends AbstractAdminController
         private readonly ConfigEnvironment $configEnvironment,
         private readonly PhaseServiceInterface $phaseService,
         private readonly TranslatorInterface $translator,
+        private readonly EntityManagerInterface $entityManager,
         public readonly InscriptionOpportunityServiceInterface $inscriptionOpportunityService,
     ) {
     }
@@ -390,15 +392,19 @@ class ProposalAdminController extends AbstractAdminController
             // Verificar se a proposta tem status "Anuída" ou "Selecionada"
             if ($proposalStatus === StatusProposalEnum::ANUIDA->value || $proposalStatus === StatusProposalEnum::SELECIONADA->value) {
                 $this->addFlash('error', $this->translator->trans('view.proposal.error.cannot_delete_approved'));
-                return $this->redirectToRoute('admin_regmel_proposal_list');
+                return $this->redirectToRoute('admin_dashboard');
             }
 
             $this->initiativeService->remove($id);
+            
+            // Limpar cache do Doctrine para forçar recalcular no dashboard
+            $this->entityManager->clear();
+            
             $this->addFlashSuccess($this->translator->trans('view.proposal.message.deleted'));
         } catch (Exception $exception) {
             $this->addFlash('error', $exception->getMessage());
         }
 
-        return $this->redirectToRoute('admin_regmel_proposal_list');
+        return $this->redirectToRoute('admin_dashboard');
     }
 }

--- a/src/Repository/InitiativeRepository.php
+++ b/src/Repository/InitiativeRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Agent;
 use App\Entity\Initiative;
 use App\Repository\Interface\InitiativeRepositoryInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -67,5 +68,22 @@ class InitiativeRepository extends AbstractRepository implements InitiativeRepos
             ['id' => $ids],
             ['createdAt' => 'DESC']
         );
+    }
+
+    public function countProposals(?Agent $createdBy = null): int
+    {
+        $connection = $this->getEntityManager()->getConnection();
+        $queryBuilder = $connection->createQueryBuilder()
+            ->select('COUNT(*) as total')
+            ->from('initiative', 'i')
+            ->where("(i.extra_fields->>'map_file' IS NOT NULL OR i.extra_fields->>'project_file' IS NOT NULL)")
+            ->andWhere('i.deleted_at IS NULL');
+
+        if ($createdBy) {
+            $queryBuilder->andWhere('i.created_by_id = :createdById')
+                ->setParameter('createdById', $createdBy->getId());
+        }
+
+        return (int) $queryBuilder->executeQuery()->fetchOne();
     }
 }

--- a/src/Service/InitiativeService.php
+++ b/src/Service/InitiativeService.php
@@ -177,4 +177,9 @@ readonly class InitiativeService extends AbstractEntityService implements Initia
 
         return $this->repository->findByFilters($region, $state, $cityName, $status, $anticipation);
     }
+
+    public function countProposals(?Agent $createdBy = null): int
+    {
+        return $this->repository->countProposals($createdBy);
+    }
 }


### PR DESCRIPTION
- Adicionar countProposals() ao InitiativeRepository para query direta ao banco
- Implementar countProposals() no InitiativeService delegando ao repositório
- Atualizar DashboardAdminController para usar countProposals() sem cache
- Adicionar EntityManager ao ProposalAdminController para limpar cache após exclusão
- Alterar redirecionamento em ProposalAdminController::remove() para admin_dashboard
- Garantir que dashboard recalcule propostas com dados frescos

<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/be1dbfb9-a2fb-446d-9939-61608262c0a6" />
