### PR TITLE
feat(soft-delete-propostas): Implementar exclusão e exibir na planilha

### DIFF
--- a/src/Entity/Initiative.php
+++ b/src/Entity/Initiative.php
@@ -228,6 +228,86 @@ class Initiative extends AbstractEntity
         $this->deletedAt = $deletedAt;
     }
 
+    public function isDeleted(): bool
+    {
+        $extraFields = $this->extraFields ?? [];
+        return $extraFields['is_deleted'] ?? false;
+    }
+
+    public function setIsDeleted(bool $isDeleted): void
+    {
+        if (!is_array($this->extraFields)) {
+            $this->extraFields = [];
+        }
+        $this->extraFields['is_deleted'] = $isDeleted;
+    }
+
+    public function getDeletedTime(): ?DateTime
+    {
+        $extraFields = $this->extraFields ?? [];
+        $deletedTime = $extraFields['deleted_time'] ?? null;
+        
+        if (empty($deletedTime)) {
+            return null;
+        }
+        
+        if ($deletedTime instanceof DateTime) {
+            return $deletedTime;
+        } elseif (is_string($deletedTime)) {
+            try {
+                return new DateTime($deletedTime);
+            } catch (\Exception $e) {
+                return null;
+            }
+        } elseif (is_array($deletedTime) && isset($deletedTime['date'])) {
+            // Caso seja serializado como array pelo Doctrine
+            try {
+                return new DateTime($deletedTime['date']);
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
+        
+        return null;
+    }
+
+    public function setDeletedTime(?DateTime $deletedTime): void
+    {
+        if (!is_array($this->extraFields)) {
+            $this->extraFields = [];
+        }
+        // Converter DateTime para ISO 8601 string para armazenar em JSON
+        $this->extraFields['deleted_time'] = $deletedTime ? $deletedTime->format(DATE_ATOM) : null;
+    }
+
+    public function getDeletedBy(): ?string
+    {
+        $extraFields = $this->extraFields ?? [];
+        return $extraFields['deleted_by_name'] ?? null;
+    }
+
+    public function setDeletedBy(?string $deletedByName): void
+    {
+        if (!is_array($this->extraFields)) {
+            $this->extraFields = [];
+        }
+        $this->extraFields['deleted_by_name'] = $deletedByName;
+    }
+
+    public function getDeletionReason(): ?string
+    {
+        $extraFields = $this->extraFields ?? [];
+        return $extraFields['deletion_reason'] ?? null;
+    }
+
+    public function setDeletionReason(?string $deletionReason): void
+    {
+        if (!is_array($this->extraFields)) {
+            $this->extraFields = [];
+        }
+        $this->extraFields['deletion_reason'] = $deletionReason;
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
+++ b/src/Regmel/Controller/Web/Admin/ProposalAdminController.php
@@ -233,7 +233,8 @@ class ProposalAdminController extends AbstractAdminController
             $municipality = $agent->getOrganizations()->first();
             $initiatives = $this->initiativeService->list(limit: 10000, params: ['organizationTo' => $municipality]);
         } else {
-            $initiatives = $this->initiativeService->list(limit: 10000);
+            // Incluir propostas deletadas na exportação CSV
+            $initiatives = $this->initiativeService->listAllIncludingDeleted(limit: 10000);
         }
 
         return $this->proposalService->generateSpreadSheet($initiatives, 'propostas', null);
@@ -377,6 +378,38 @@ class ProposalAdminController extends AbstractAdminController
         $status = $body['status'] ?? '';
 
         $this->proposalService->bulkUpdateStatus($selectedRows, $status);
+
+        return $this->redirectToRoute('admin_regmel_proposal_list');
+    }
+
+    #[IsGranted(UserRolesEnum::ROLE_ADMIN->value, statusCode: self::ACCESS_DENIED_RESPONSE_CODE)]
+    #[Route('/painel/admin/propostas/{id}/deletar', name: 'admin_regmel_proposal_soft_delete', methods: ['POST'])]
+    public function softDelete(Uuid $id, Request $request): Response
+    {
+        try {
+            $proposal = $this->initiativeService->get($id);
+            $proposalStatus = $proposal->getExtraFields()['status'] ?? '';
+            $deletionReason = $request->request->get('deletion_reason');
+
+            // Validar se a proposta está anuída ou selecionada
+            if ($proposalStatus === StatusProposalEnum::ANUIDA->value || $proposalStatus === StatusProposalEnum::SELECIONADA->value) {
+                $this->addFlash('error', $this->translator->trans('view.proposal.error.cannot_delete_anuida_selecionada'));
+                return $this->redirectToRoute('admin_regmel_proposal_list');
+            }
+
+            // Validação do motivo
+            if (empty($deletionReason) || strlen($deletionReason) < 20) {
+                $this->addFlash('error', $this->translator->trans('view.proposal.error.deletion_reason_required'));
+                return $this->redirectToRoute('admin_regmel_proposal_list');
+            }
+
+            // Realizar soft delete
+            $this->proposalService->softDeleteProposal($id, $deletionReason);
+
+            $this->addFlashSuccess($this->translator->trans('view.proposal.message.soft_deleted'));
+        } catch (Exception $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
 
         return $this->redirectToRoute('admin_regmel_proposal_list');
     }

--- a/src/Regmel/Service/Interface/ProposalServiceInterface.php
+++ b/src/Regmel/Service/Interface/ProposalServiceInterface.php
@@ -24,6 +24,8 @@ interface ProposalServiceInterface
 
     public function updateStatusProposal(Uuid $id, StatusProposalEnum $status, string $reason): void;
 
+    public function softDeleteProposal(Uuid $id, string $deletionReason): void;
+
     public function exportProjectFiles(array $proposals): string;
 
     public function exportMapFiles(array $proposals): string;

--- a/src/Regmel/Service/ProposalService.php
+++ b/src/Regmel/Service/ProposalService.php
@@ -276,6 +276,10 @@ readonly class ProposalService extends AbstractEntityService implements Proposal
             $this->translator->trans('csv.header.created_by'),
             $this->translator->trans('csv.header.proposal_date'),
             $this->translator->trans('csv.header.proposal_update_date'),
+            'Status de Exclusão',
+            'Motivo da Exclusão',
+            'Excluída por',
+            'Data/Hora de Exclusão',
         ];
     }
 
@@ -349,6 +353,11 @@ readonly class ProposalService extends AbstractEntityService implements Proposal
             $entity->getCreatedBy()?->getName() ?? '',
             $entity->getCreatedAt()->format('d/m/Y H:i:s'),
             $modificationDate,
+            // Dados de exclusão
+            $entity->isDeleted() ? 'Sim' : 'Não',
+            $entity->getDeletionReason() ?? '',
+            $entity->getDeletedBy() ?? '',
+            $entity->getDeletedTime()?->format('d/m/Y H:i:s') ?? '',
         ];
     }
 
@@ -491,5 +500,31 @@ readonly class ProposalService extends AbstractEntityService implements Proposal
         $user = $this->security->getUser();
         $userName = $user ? $user->getName() : 'Usuário Desconhecido';
         $this->proposalRepository->bulkUpdateStatus($proposals, $status, $userName);
+    }
+
+    public function softDeleteProposal(Uuid $id, string $deletionReason): void
+    {
+        $proposal = $this->entityManager->getRepository(Initiative::class)->find($id);
+
+        if (!$proposal) {
+            throw new InvalidArgumentException($this->translator->trans('error.invalid_entity'));
+        }
+
+        $user = $this->security->getUser();
+
+        // Marcar como excluída usando extraFields
+        $proposal->setIsDeleted(true);
+        $proposal->setDeletedTime(new DateTime());
+        $proposal->setDeletedBy($user->getName());
+        $proposal->setDeletionReason($deletionReason);
+
+        // Atualizar status da proposta para "Excluída"
+        $extraFields = $proposal->getExtraFields() ?? [];
+        $extraFields['status'] = 'Excluída';
+        $proposal->setExtraFields($extraFields);
+
+        // Persistir as mudanças
+        $this->entityManager->persist($proposal);
+        $this->entityManager->flush();
     }
 }

--- a/src/Repository/InitiativeRepository.php
+++ b/src/Repository/InitiativeRepository.php
@@ -64,26 +64,66 @@ class InitiativeRepository extends AbstractRepository implements InitiativeRepos
             return [];
         }
 
-        return $this->findBy(
+        $initiatives = $this->findBy(
             ['id' => $ids],
             ['createdAt' => 'DESC']
         );
+
+        // Filtrar em memória as propostas deletadas (is_deleted = false)
+        return array_filter($initiatives, function(Initiative $initiative) {
+            return !$initiative->isDeleted();
+        });
     }
 
     public function countProposals(?Agent $createdBy = null): int
     {
         $connection = $this->getEntityManager()->getConnection();
         $queryBuilder = $connection->createQueryBuilder()
-            ->select('COUNT(*) as total')
+            ->select('i.id')
             ->from('initiative', 'i')
             ->where("(i.extra_fields->>'map_file' IS NOT NULL OR i.extra_fields->>'project_file' IS NOT NULL)")
-            ->andWhere('i.deleted_at IS NULL');
+            ->andWhere('i.deleted_at IS NULL')
+            ->orderBy('i.created_at', 'DESC');
 
         if ($createdBy) {
             $queryBuilder->andWhere('i.created_by_id = :createdById')
                 ->setParameter('createdById', $createdBy->getId());
         }
 
-        return (int) $queryBuilder->executeQuery()->fetchOne();
+        $ids = $queryBuilder->executeQuery()->fetchFirstColumn();
+        
+        if (empty($ids)) {
+            return 0;
+        }
+        
+        // Filtrar em memória as propostas deletadas
+        $proposals = $this->findBy(['id' => $ids]);
+        $notDeletedProposals = array_filter($proposals, function(Initiative $initiative) {
+            return !$initiative->isDeleted();
+        });
+        
+        return count($notDeletedProposals);
+    }
+
+    public function findAllIncludingDeleted(int $limit = 50, array $params = [], string $order = 'DESC'): array
+    {
+        $connection = $this->getEntityManager()->getConnection();
+        $queryBuilder = $connection->createQueryBuilder()
+            ->select('i.id')
+            ->from('initiative', 'i')
+            ->where("(i.extra_fields->>'map_file' IS NOT NULL OR i.extra_fields->>'project_file' IS NOT NULL)")
+            ->andWhere('i.deleted_at IS NULL')
+            ->orderBy('i.created_at', $order)
+            ->setMaxResults($limit);
+
+        $ids = $queryBuilder->executeQuery()->fetchFirstColumn();
+        if (empty($ids)) {
+            return [];
+        }
+
+        return $this->findBy(
+            ['id' => $ids],
+            ['createdAt' => $order]
+        );
     }
 }

--- a/src/Service/InitiativeService.php
+++ b/src/Service/InitiativeService.php
@@ -178,6 +178,11 @@ readonly class InitiativeService extends AbstractEntityService implements Initia
         return $this->repository->findByFilters($region, $state, $cityName, $status, $anticipation);
     }
 
+    public function listAllIncludingDeleted(int $limit = 50, array $params = [], string $order = 'DESC'): array
+    {
+        return $this->repository->findAllIncludingDeleted($limit, $params, $order);
+    }
+
     public function countProposals(?Agent $createdBy = null): int
     {
         return $this->repository->countProposals($createdBy);

--- a/src/Service/Interface/InitiativeServiceInterface.php
+++ b/src/Service/Interface/InitiativeServiceInterface.php
@@ -24,6 +24,8 @@ interface InitiativeServiceInterface
 
     public function list(int $limit = 50, array $params = [], string $order = 'DESC'): array;
 
+    public function listAllIncludingDeleted(int $limit = 50, array $params = [], string $order = 'DESC'): array;
+
     public function count(?Agent $createdBy = null): int;
 
     public function remove(Uuid $id): void;

--- a/templates/regmel/admin/proposal/list.html.twig
+++ b/templates/regmel/admin/proposal/list.html.twig
@@ -75,6 +75,38 @@
                         </div>
                     </div>
 
+                    <div class="modal fade" id="modalProposalDelete" tabindex="-1" aria-labelledby="modalProposalDeleteLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <form id="proposalDeleteForm" method="post">
+                                    <div class="modal-header">
+                                        <h1 class="modal-title fs-5" id="modalProposalDeleteLabel">Excluir Proposta</h1>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="alert alert-warning" role="alert">
+                                            <strong>Atenção!</strong> A exclusão de uma proposta não pode ser desfeita. A proposta será marcada como excluída mas permanecerá nos registros históricos.
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <label for="deletionReasonText" class="form-label fw-bold">Motivo da Exclusão *</label>
+                                            <textarea name="deletion_reason" id="deletionReasonText" class="form-control" rows="4"
+                                                      placeholder="Descreva o motivo da exclusão (mínimo 20 caracteres)..." required
+                                                      minlength="20"
+                                                      maxlength="1000"></textarea>
+                                            <div class="form-text">Mínimo de 20 caracteres obrigatório</div>
+                                            <small class="d-block mt-2">Caracteres: <span id="charCount">0</span>/1000</small>
+                                        </div>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                                        <button type="submit" class="btn btn-danger" id="deletionSubmitBtn" disabled>Excluir Proposta</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+
                     <table class="js-grid table table-hover table-striped">
                         <thead class="table-dark">
                         <tr>
@@ -167,9 +199,8 @@
                                                         class="dropdown-item text-danger"
                                                         data-cy="remove-{{ proposal.id }}"
                                                         data-bs-toggle="modal"
-                                                        data-bs-target="#modalRemoveConfirm"
-                                                        onclick="confirmRemove(this)"
-                                                        data-href="{{ path('admin_regmel_proposal_remove', {id: proposal.id}) }}"
+                                                        data-bs-target="#modalProposalDelete"
+                                                        onclick="openProposalDeleteModal('{{ proposal.id }}', '{{ proposal.name }}')"
                                                 >
                                                     Excluir Proposta
                                                 </a>
@@ -209,5 +240,48 @@
             const form = document.getElementById('proposalStatusForm');
             form.action = `/painel/admin/propostas/${proposalId}/status`;
         }
+
+        function openProposalDeleteModal(proposalId, proposalName) {
+            const form = document.getElementById('proposalDeleteForm');
+            const textarea = document.getElementById('deletionReasonText');
+            const submitBtn = document.getElementById('deletionSubmitBtn');
+            
+            // Limpar valores anteriores
+            textarea.value = '';
+            submitBtn.disabled = true;
+            document.getElementById('charCount').textContent = '0';
+            
+            // Atualizar ação do form
+            form.action = `/painel/admin/propostas/${proposalId}/deletar`;
+            
+            // Atualizar título do modal
+            document.getElementById('modalProposalDeleteLabel').textContent = `Excluir Proposta: ${proposalName}`;
+        }
+
+        // Validação em tempo real do campo de motivo de exclusão
+        document.getElementById('deletionReasonText')?.addEventListener('input', function() {
+            const submitBtn = document.getElementById('deletionSubmitBtn');
+            const charCount = document.getElementById('charCount');
+            
+            charCount.textContent = this.value.length;
+            
+            // Habilitar botão apenas se tiver pelo menos 20 caracteres
+            if (this.value.length >= 20) {
+                submitBtn.disabled = false;
+            } else {
+                submitBtn.disabled = true;
+            }
+        });
+
+        // Validar envio do formulário de exclusão
+        document.getElementById('proposalDeleteForm')?.addEventListener('submit', function(e) {
+            const textarea = document.getElementById('deletionReasonText');
+            
+            if (textarea.value.length < 20) {
+                e.preventDefault();
+                alert('O motivo da exclusão deve ter no mínimo 20 caracteres.');
+                return false;
+            }
+        });
     </script>
 {% endblock %}

--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -861,8 +861,11 @@ view:
   proposal:
     message:
       deleted: A proposta foi excluída
+      soft_deleted: A proposta foi marcada como excluída com sucesso
     error:
       cannot_delete_approved: Não é possível excluir uma proposta que foi anuída ou selecionada
+      cannot_delete_anuida_selecionada: Não é possível excluir uma proposta com status Anuída ou Selecionada
+      deletion_reason_required: O motivo da exclusão é obrigatório e deve ter no mínimo 20 caracteres
     project_linked_program: Este projeto está vinculado ao programa programa-nome e foi selecionado por meio da oportunidade oportunidade-nome.
     quantity:
       total: Iniciativas Encontradas


### PR DESCRIPTION
Implementa exclusão de propostas e exibe as propostas ecxluidas na planilha

- Adicionar funcionalidade de soft delete (exclusão suave) para propostas
- Implementar modal com validação obrigatória do motivo (mínimo 20 caracteres)
- Restringir acesso à função apenas para administradores (ROLE_ADMIN)
- Bloquear exclusão de propostas com status 'Anuída' ou 'Selecionada'
- Armazenar metadados de exclusão em JSON (reason, user, timestamp)
- Atualizar dashboard para excluir propostas deletadas da contagem
- Incluir propostas deletadas no export CSV com informações de exclusão
- Adicionar traduções para mensagens de erro e sucesso

Prints
<img width="1316" height="736" alt="image" src="https://github.com/user-attachments/assets/6d2c7ec0-1109-47ea-90e9-81e09040629e" />
Impede que propostas anuídas ou selecionadas sejam excluídas.

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e772084f-603e-44ab-b412-3543134412d6" />
Novo campo de motivo no modal do botão de exclusão

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f73e3ab4-138b-424a-9dbb-b1a4c153c7ef" />
Proposta excluída com sucesso

<img width="1053" height="404" alt="image" src="https://github.com/user-attachments/assets/150b129d-0754-4260-9da4-0f97c86afe32" />
Dados da exclusão exibidos na planilha